### PR TITLE
Update env.py to use POSTGRES_SERVER from env variable

### DIFF
--- a/src/migrations/env.py
+++ b/src/migrations/env.py
@@ -14,7 +14,7 @@ config = context.config
 
 config.set_main_option(
     "sqlalchemy.url",
-    f"{settings.POSTGRES_ASYNC_PREFIX}{settings.POSTGRES_USER}:{settings.POSTGRES_PASSWORD}@localhost/{settings.POSTGRES_DB}",
+    f"{settings.POSTGRES_ASYNC_PREFIX}{settings.POSTGRES_USER}:{settings.POSTGRES_PASSWORD}@{settings.POSTGRES_SERVER}/{settings.POSTGRES_DB}",
 )
 
 # Interpret the config file for Python logging.


### PR DESCRIPTION
- Replace hardcoded `localhost` with POSTGRES_SERVER env var.
- Without this fix, migration will fail in cases where anything other than `localhost` is used in local environment.